### PR TITLE
Added 'HTTP_HOST' to the key for use in apc_define_constants function

### DIFF
--- a/public/_loader.php
+++ b/public/_loader.php
@@ -32,7 +32,7 @@ if (function_exists('apc_load_constants')) {
 // Paths
 $root = realpath(dirname(__FILE__) . '/../');
 
-define_array('PATH', array(
+define_array('PATH-' . $_SERVER['HTTP_HOST'], array(
     'PATH_ROOT' => $root,
     'PATH_APPLICATION' => $root . '/application',
     'PATH_DATA' => $root . '/data',


### PR DESCRIPTION
Constants should be cached with unique key for the hostname. This will prevent the errors with the equal ROOT_PATH for different sites at the same server.
