### PR TITLE
Sessions initialization error

### DIFF
--- a/application/configs/application.php
+++ b/application/configs/application.php
@@ -41,7 +41,7 @@ return array(
     ),
     "session" => array(
         "store" => "session",
-        "options" => array(
+        "parameters" => array(
             "savepath" => PATH_DATA .'/sessions'
         )
     ),


### PR DESCRIPTION
"options" key renamed to "parameters" due to changes in Session class.
