### PR TITLE
Fixed reflaction bug: add PHPDocs tag param in all necessary controllers

### DIFF
--- a/application/modules/acl/controllers/edit-user.php
+++ b/application/modules/acl/controllers/edit-user.php
@@ -7,6 +7,7 @@ namespace Application;
 
 return
 /**
+ * @param int $id
  * @privilege Edit
  *
  * @return \closure

--- a/application/modules/error/controllers/index.php
+++ b/application/modules/error/controllers/index.php
@@ -11,7 +11,7 @@ use Bluz;
 return
 /**
  * @route  /error/{$code}
- * @param  integer $code
+ * @param  int $code
  * @param  string $message
  * @return \closure
  */

--- a/application/modules/test/api/example.php
+++ b/application/modules/test/api/example.php
@@ -8,7 +8,7 @@
 namespace Application;
 return
 /**
- * @param integer $num
+ * @param int $num
  * @return \closure
  */
 function($num) {

--- a/application/modules/test/controllers/cache-view.php
+++ b/application/modules/test/controllers/cache-view.php
@@ -11,7 +11,7 @@ use Bluz;
 return
 /**
  * @cache 2
- * @param integer $a
+ * @param int $a
  * @return \closure
  */
 function($a = 0) use ($view) {

--- a/application/modules/test/controllers/create.php
+++ b/application/modules/test/controllers/create.php
@@ -13,6 +13,7 @@ return
 /**
  * @method GET
  * @method POST
+ * @param array $data
  * @return \closure
  */
 function($data = array()) use ($view) {

--- a/application/modules/test/controllers/delete.php
+++ b/application/modules/test/controllers/delete.php
@@ -12,6 +12,7 @@ namespace Application;
 return
 /**
  * @method DELETE
+ * @param int $id
  * @return \closure
  */
 function($id) use ($view) {

--- a/application/modules/test/controllers/mailer.php
+++ b/application/modules/test/controllers/mailer.php
@@ -9,6 +9,7 @@ namespace Application;
 
 return
 /**
+ * @param string $email
  * @return \closure
  */
 function($email = "no-reply@nixsolutions.com") use ($view) {

--- a/application/modules/test/controllers/read.php
+++ b/application/modules/test/controllers/read.php
@@ -12,7 +12,7 @@ namespace Application;
 return
 /**
  * @method GET
- * @param integer $id
+ * @param int $id
  * @return \closure
  */
 function($id = null) use ($view) {

--- a/application/modules/test/controllers/update.php
+++ b/application/modules/test/controllers/update.php
@@ -15,6 +15,8 @@ return
 /**
  * @method GET
  * @method PUT
+ * @param int $id
+ * @param array $data
  * @return \closure
  */
 function($id, $data = array()) use ($view) {

--- a/application/modules/test/controllers/view-helpers.php
+++ b/application/modules/test/controllers/view-helpers.php
@@ -11,6 +11,9 @@ namespace Application;
 
 return
 /**
+ * @param bool $sex
+ * @param string $car
+ * @param bool $remember
  * @return \closure
  */
 function($sex = false, $car = 'none', $remember = false) use ($view) {

--- a/application/modules/users/controllers/mail-template.php
+++ b/application/modules/users/controllers/mail-template.php
@@ -11,6 +11,8 @@ namespace Application;
 
 return
     /**
+     * @param string $template
+     * @param array $vars
      * @return \closure
      */
     function ($template, $vars = []) use ($view) {

--- a/application/modules/users/controllers/recovery-reset.php
+++ b/application/modules/users/controllers/recovery-reset.php
@@ -17,6 +17,8 @@ return
      *
      * @param int $id User UID
      * @param string $code
+     * @param string $password
+     * @param string $password2
      * @return \closure
      */
     function ($id, $code, $password = null, $password2 = null) use ($view) {

--- a/application/modules/users/controllers/recovery.php
+++ b/application/modules/users/controllers/recovery.php
@@ -13,6 +13,7 @@ use Application\Users;
 
 return
     /**
+     * @param string $email
      * @return \closure
      */
     function ($email = null) use ($view) {

--- a/application/modules/users/controllers/signin.php
+++ b/application/modules/users/controllers/signin.php
@@ -10,8 +10,8 @@ use Bluz;
 use Application\Auth;
 return
 /**
- * @param $login
- * @param $password
+ * @param string $login
+ * @param string $password
  * @return \closure
  */
 function($login, $password) use ($view) {

--- a/application/modules/users/controllers/signout.php
+++ b/application/modules/users/controllers/signout.php
@@ -10,8 +10,6 @@ namespace Application;
 use Bluz;
 return
 /**
- * @param $login
- * @param $password
  * @return \closure
  */
 function() use ($view) {


### PR DESCRIPTION
В контроллеры добавил недостающие и удалил ненужные теги @param. 
Привел типы данных к одному варианту (int, integer -> int; bool,boolean -> bool e.g.)
