### PR TITLE
delete defines a constant DEBUG from test/bootstrap.php

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,5 @@
 <?php
 // Environment
-define('DEBUG', true);
 error_reporting(E_ALL | E_STRICT);
 ini_set('display_errors', 1);
 


### PR DESCRIPTION
fixed notice when run tests from the console 
PHP Notice:  Constant DEBUG already defined in /home/dev/bluz/application/_loader.php on line 31
