### PR TITLE
Fix registration via social networks

### DIFF
--- a/application/configs/default/auth.php
+++ b/application/configs/default/auth.php
@@ -16,7 +16,7 @@ return array(
         "secret" => "%%secret%%",
     ),
     "twitter" => array(
-        "consumerKey" => "%%consumerKey%%",
-        "consumerSecret" => "%%consumerSecret%%"
+        "consumer_key" => "%%consumerKey%%",
+        "consumer_secret" => "%%consumerSecret%%"
     )
 );

--- a/application/library/Twitter/Client.php
+++ b/application/library/Twitter/Client.php
@@ -59,7 +59,7 @@ class Client extends GuzzleClient
      * Get request token from API
      *
      * $callbackUrl = $this->getRouter()->getFullUrl('twitter', 'callback');
-     * $oauthRequestToken = $twitterAuth->getOauthRequestToken($callbackUrl);     *
+     * $oauthRequestToken = $twitterAuth->getOauthRequestToken($callbackUrl);
      *
      * @param string $callbackUrl
      * @throws \Exception

--- a/application/models/Roles/Table.php
+++ b/application/models/Roles/Table.php
@@ -26,6 +26,7 @@ class Table extends \Bluz\Db\Table
     const BASIC_GUEST = 'guest';
     const BASIC_MEMBER = 'member';
     const BASIC_ADMIN = 'admin';
+    const BASIC_SOCIAL = 'social';
     /**
      * Table
      *
@@ -42,7 +43,7 @@ class Table extends \Bluz\Db\Table
     /**
      * @var array
      */
-    protected $basicRoles = ['guest', 'member', 'admin'];
+    protected $basicRoles = ['guest', 'member', 'admin', 'social'];
 
     /**
      * Get all roles in system

--- a/application/models/Users/Crud.php
+++ b/application/models/Users/Crud.php
@@ -50,6 +50,7 @@ class Crud extends \Bluz\Crud\Table
         $row = $this->getTable()->create();
         $row->setFromArray($data);
         $row->status = Table::STATUS_PENDING;
+        $row->addValidation();
         $row->save();
 
         $userId = $row->id;

--- a/application/models/Users/Row.php
+++ b/application/models/Users/Row.php
@@ -43,9 +43,11 @@ class Row extends AbstractRowEntity
     protected $privileges;
 
     /**
+     * Adds validators for creation via the web form
+     *
      * @return void
      */
-    public function beforeSave()
+    public function addValidation()
     {
         $this->email = strtolower($this->email);
 

--- a/application/modules/users/controllers/change-credentials.php
+++ b/application/modules/users/controllers/change-credentials.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Change credentials controller
+ * Allowed only for those who registered via social networks
+ *
+ * @author  Dmitriy Rassadkin <volkov.sergey@nixsolutions.com>
+ * @created 02.10.2014 11:45
+ */
+namespace Application;
+
+/**
+ * @privilege EditCredentials
+ */
+use Bluz\Validator\Exception\ValidatorException;
+use Bluz\Controller;
+
+return
+
+    function () {
+        /**
+         * @var Bootstrap $this
+         */
+        //set email and password for those who registered by social networks
+        if (!$this->getRequest()->isXmlHttpRequest()) {
+            $this->useLayout('small.phtml');
+        }
+
+        if ($this->getRequest()->isPost()) {
+            try {
+                if (!$login = $this->getRequest()->getParam('login')) {
+                    throw ValidatorException::exception('login', __('Login can\'t be empty'));
+                }
+
+                if (!$email = $this->getRequest()->getParam('email')) {
+                    throw ValidatorException::exception('email', __('Email can\'t be empty'));
+                }
+
+                if (!$password = $this->getRequest()->getParam('password')) {
+                    throw ValidatorException::exception('password', __('Password can\'t be empty'));
+                }
+
+                if ($password !== $this->getRequest()->getParam('password2')) {
+                    throw ValidatorException::exception('password2', 'Passwords aren\'t equal');
+                }
+
+                //update user info
+                $row = Users\Table::findRow($this->user()->id);
+                $row->login = $login;
+                $row->email = $email;
+                $row->addValidation();
+                $row->save();
+
+                //set password
+                $authTable = Auth\Table::getInstance();
+                $authTable->generateEquals($row, $password);
+
+                //change role to member
+                $memberRow = Roles\Table::findRowWhere(['name' => Roles\Table::BASIC_MEMBER]);
+                $socialRow = Roles\Table::findRowWhere(['name' => Roles\Table::BASIC_SOCIAL]);
+                UsersRoles\Table::update(
+                    ['roleId' => $memberRow->id],
+                    ['userId' => $this->user()->id, 'roleId' => $socialRow->id]
+                );
+                $row->login();
+
+                $this->getMessages()->addSuccess("Your account was successfully updated");
+                $this->redirectTo('index', 'index');
+            } catch (ValidatorException $e) {
+                return ['errors' => $e->getErrors()];
+            }
+        }
+    };

--- a/application/modules/users/views/change-credentials.phtml
+++ b/application/modules/users/views/change-credentials.phtml
@@ -1,0 +1,25 @@
+<?php $uid = uniqid('form_');?>
+<h3 class="page-header"><?=__('Set your credentials')?></h3>
+<form id="<?=$uid?>" action="<?=$this->url('users', 'change-credentials')?>" class="ajax form-horizontal" method="POST">
+    <div class="form-group input-group">
+        <span class="input-group-addon"><i class="fa fa-user"></i></span>
+        <input type="text" class="form-control" name="login"
+               placeholder="<?=__('login')?>" required/>
+    </div>
+    <div class="form-group input-group">
+        <span class="input-group-addon"><i class="fa fa-envelope"></i></span>
+        <input type="text" class="form-control" name="email"
+               placeholder="<?=__('email')?>" required/>
+    </div>
+    <div class="form-group input-group">
+        <span class="input-group-addon"><i class="fa fa-lock"></i></span>
+        <input type="password" class="form-control" name="password"
+               placeholder="<?=__('password')?>" required/>
+    </div>
+    <div class="form-group input-group">
+        <span class="input-group-addon"><i class="fa fa-lock"></i></span>
+        <input type="password" class="form-control" name="password2"
+               placeholder="<?=__('repeat your password')?>" required/>
+    </div>
+    <button type="submit" class="btn btn-primary"><?=__('Save')?></button>
+</form>

--- a/application/modules/users/views/profile.phtml
+++ b/application/modules/users/views/profile.phtml
@@ -7,8 +7,9 @@
 <h3 class="page-header">
     <?=__('Profile')?>
     <?php if ($this->user()->id == $user->id) : ?>
-        <?=$this->ahref(__('Change email'), ['users', 'change-email'], ['class'=>'btn btn-mini pull-right'])?>
-        <?=$this->ahref(__('Change password'), ['users', 'change-password'], ['class'=>'btn btn-mini pull-right'])?>
+        <?=$this->ahref(__('Set credentials'), ['users', 'change-credentials', [], true], ['class'=>'btn btn-mini pull-right'])?>
+        <?=$this->ahref(__('Change email'), ['users', 'change-email', [], true], ['class'=>'btn btn-mini pull-right'])?>
+        <?=$this->ahref(__('Change password'), ['users', 'change-password', [], true], ['class'=>'btn btn-mini pull-right'])?>
     <?php endif; ?>
 </h3>
 <dl class="dl-horizontal">

--- a/dump.sql
+++ b/dump.sql
@@ -28,9 +28,14 @@ LOCK TABLES `acl_privileges` WRITE;
 
 INSERT INTO `acl_privileges` (`roleId`, `module`, `privilege`)
 VALUES
+  (4,'users','EditCredentials'),
   (3,'users','ViewProfile'),
   (2,'media','Upload'),
   (2,'users','ViewProfile'),
+  (2,'users','EditPassword'),
+  (2,'users','EditEmail'),
+  (1,'users','EditPassword'),
+  (1,'users','EditEmail'),
   (1,'acl','Edit'),
   (1,'acl','View'),
   (1,'cache','Management'),
@@ -42,8 +47,7 @@ VALUES
   (1,'pages','Management'),
   (1,'system','Info'),
   (1,'users','Management'),
-  (1,'users','ViewProfile')
-;
+  (1,'users','ViewProfile');
 
 /*!40000 ALTER TABLE `acl_privileges` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -59,7 +63,8 @@ INSERT INTO `acl_roles` (`id`, `name`, `created`)
 VALUES
 	(1,'admin','2012-11-09 07:37:31'),
 	(2,'member','2012-11-09 07:37:37'),
-	(3,'guest','2012-11-09 07:37:44');
+	(3,'guest','2012-11-09 07:37:44'),
+	(4,'social','2014-10-02 18:39:15');
 
 /*!40000 ALTER TABLE `acl_roles` ENABLE KEYS */;
 UNLOCK TABLES;


### PR DESCRIPTION
Добавлена роль в системе social, которой помечаются аккаунты, созданные посредством логина через соц.сети, у которых есть доступ к странице выбора логина, эмейла, пароля, и нет доступа к страницам смены эмейла/пароля.(доступ к странице из профиля, а также автоматический редирект на нее после первого логина через соц. сеть). После сохранения креденшелов аккаунта, ему присваивается роль member.
Для избежания повторяющихся логинов в базе, при регистрации через соц. сеть генерируется уникальное имя с приставкой названия соц. сети, напр. twitter_5432b81aeafc7.
