### PR TITLE
Fixed registration

### DIFF
--- a/application/modules/users/controllers/signup.php
+++ b/application/modules/users/controllers/signup.php
@@ -16,6 +16,7 @@ use Bluz\Proxy\Request;
 return
 /**
  * @accept JSON
+ * @accept HTML
  * @return \closure
  */
 function () {


### PR DESCRIPTION
Controller 'signup.php' could accept 'html' data the same as 'json' data. Otherwise will be error 'Not acceptable'.